### PR TITLE
Update prefixValue to use regex based logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,12 @@ const prefix = (prop, value) => {
   return css;
 };
 ```
+
+Additionally `prefixValue` can accept full declarations to avoid
+having to apply it before concatenation, which can be useful in case
+you're trying to minimise string operations:
+
+```js
+const declaration = 'position: sticky';
+prefixValue(declaration, declaration); // 'position: -webkit-sticky, sticky'
+```

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,8 @@ export const prefixProperty = prop => {
 };
 
 export const prefixValue = (prop, value) => {
-  if (
-    (prop === 'position' && value === 'sticky') ||
-    (prop === 'background-clip' && value === 'text')
-  ) {
-    return `-webkit-${value}, ${value}`;
+  if (webkitValuePrefixRe.test(prop)) {
+    return value.replace(/(sticky|text)/, '-webkit-$1, $1');
   }
 
   return value;


### PR DESCRIPTION
This doesn't change the size but allows the `prefixValue` function to also be used with a full declaration by passing the declaration for both arguments:

```js
const declaration = 'position: sticky';
prefixValue(declaration, declaration); // 'position: -webkit-sticky, sticky'
```