### PR TITLE
upgrade dependencies for ie_mob deprecation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tiny-css-prefixer",
   "description": "CSS prefixing helpers in less than 1KB",
-  "version": "1.1.4",
+  "version": "2.0.0",
   "main": "dist/tiny-css-prefixer.js",
   "module": "dist/tiny-css-prefixer.es.js",
   "source": "src/index.js",
@@ -34,12 +34,12 @@
     "@rollup/plugin-commonjs": "^11.0.1",
     "@rollup/plugin-node-resolve": "^7.0.0",
     "babel-plugin-codegen": "^3.1.0",
-    "inline-style-prefixer": "^5.1.0",
-    "mdn-data": "^2.0.6",
+    "inline-style-prefixer": "^6.0.0",
+    "mdn-data": "^2.0.8",
     "npm-run-all": "^4.1.5",
     "rollup": "^1.29.0",
     "rollup-plugin-babel": "^4.3.3",
-    "rollup-plugin-filesize": "6.2.1",
+    "rollup-plugin-filesize": "^6.2.1",
     "rollup-plugin-terser": "^5.2.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -596,10 +596,10 @@ import-fresh@^3.1.0:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
 
-inline-style-prefixer@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz#cb63195f9456dcda25cf59743e45c4d9815b0811"
-  integrity sha512-giteQHPMrApQOSjNSjteO5ZGSGMRf9gas14fRy2lg2buSc1nRnj6o6xuNds5cMTKrkncyrTu3gJn/yflFMVdmg==
+inline-style-prefixer@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-6.0.0.tgz#f73d5dbf2855733d6b153a4d24b7b47a73e9770b"
+  integrity sha512-XTHvRUS4ZJNzC1GixJRmOlWSS45fSt+DJoyQC9ytj0WxQfcgofQtDtyKKYxHUqEsWCs+LIWftPF1ie7+i012Fg==
   dependencies:
     css-in-js-utils "^2.0.0"
 
@@ -731,10 +731,10 @@ magic-string@^0.25.0, magic-string@^0.25.2, magic-string@^0.25.3:
   dependencies:
     sourcemap-codec "^1.4.4"
 
-mdn-data@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.6.tgz#852dc60fcaa5daa2e8cf6c9189c440ed3e042978"
-  integrity sha512-rQvjv71olwNHgiTbfPZFkJtjNMciWgswYeciZhtvWLO8bmX3TnhyA62I6sTWOyZssWHJJjY6/KiWwqQsWWsqOA==
+mdn-data@^2.0.8:
+  version "2.0.8"
+  resolved "https://registry.yarnpkg.com/mdn-data/-/mdn-data-2.0.8.tgz#b5b1b8b9dc76abb5261bf2b8c495a0b4565af5c6"
+  integrity sha512-2gcTclvIaw9K/D3+HeX2YrSmzJYvOL7CJCGTTrHlnzQ0N4KQkB/sgRwHArP7JzlL0feUwCZQ1C0yCO/us/dSdw==
 
 memorystream@^0.3.1:
   version "0.3.1"
@@ -955,7 +955,7 @@ rollup-plugin-babel@^4.3.3:
     "@babel/helper-module-imports" "^7.0.0"
     rollup-pluginutils "^2.8.1"
 
-rollup-plugin-filesize@6.2.1:
+rollup-plugin-filesize@^6.2.1:
   version "6.2.1"
   resolved "https://registry.yarnpkg.com/rollup-plugin-filesize/-/rollup-plugin-filesize-6.2.1.tgz#552eebc88dd69db3321d99c27dbd49e550812e54"
   integrity sha512-JQ2+NMoka81lCR2caGWyngqMKpvJCl7EkFYU7A+T0dA7U1Aml13FW5Ky0aiZIeU3/13cjsKQLRr35SQVmk6i/A==


### PR DESCRIPTION
upgrade `inline-style-prefixer` - `ie_mob` was deprecated and removed from `caniuse-api` which landed in `inline-style-prefixer@6.0.0`

here is a reference to full changelog - https://github.com/robinweser/inline-style-prefixer/compare/07f2d5239e305e9e3ce89276e20ce088eb4940ac...master

upgrading the version saves 23 bytes in gzip size.

NB: I upgraded the version here to 2.0.0 just to be on safer side.